### PR TITLE
Fix: use "Tags" not "TagSet" on EC2 Instances

### DIFF
--- a/ScoutSuite/providers/aws/facade/ec2.py
+++ b/ScoutSuite/providers/aws/facade/ec2.py
@@ -188,8 +188,8 @@ class EC2Facade(AWSBaseFacade):
              if flow_log['ResourceId'] == subnet['SubnetId'] or flow_log['ResourceId'] == subnet['VpcId']]
 
     async def get_and_set_ec2_instance_tags(self, raw_instance: {}):
-        if 'TagSet' in raw_instance:
-            instance = {'tags': {x['Key']: x['Value'] for x in raw_instance['TagSet']}}
+        if 'Tags' in raw_instance:
+            instance = {'tags': {x['Key']: x['Value'] for x in raw_instance['Tags']}}
         else:
             instance = {'tags': {}}
         return instance

--- a/ScoutSuite/providers/aws/resources/ec2/instances.py
+++ b/ScoutSuite/providers/aws/resources/ec2/instances.py
@@ -28,7 +28,7 @@ class EC2Instances(AWSResources):
 
         get_name(raw_instance, instance, 'InstanceId')
         get_keys(raw_instance, instance,
-                 ['KeyName', 'LaunchTime', 'InstanceType', 'State', 'IamInstanceProfile', 'SubnetId', 'TagSet'])
+                 ['KeyName', 'LaunchTime', 'InstanceType', 'State', 'IamInstanceProfile', 'SubnetId', 'Tags'])
 
         instance['network_interfaces'] = {}
         for eni in raw_instance['NetworkInterfaces']:


### PR DESCRIPTION
The structure for EC2 Instance tags is `Tags` with `Key: <key>, Value: <value`, whereas it was assumed to be `TagSet`.  Makes this small change to fix that.