### PR TITLE
SECURE-3185: Commenting out Oracle/Ali/Azure cloud providers to shrink image sizes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,33 +31,33 @@ httplib2shim>=0.0.3
 
 # Azure Provider
 ## core requirements
-azure-cli-core==2.12.0
+#azure-cli-core==2.12.0
 ## for RBAC in AAD
-azure-graphrbac==0.61.1
-adal==1.2.4
+#azure-graphrbac==0.61.1
+#adal==1.2.4
 ## for resources
-azure-mgmt-storage==7.1.0
-azure-mgmt-monitor==0.5.2
-azure-mgmt-sql==0.11.0
-azure-mgmt-security==0.4.1
-azure-mgmt-keyvault==1.1.0
-azure-mgmt-network==2.5.1
-azure-mgmt-redis==6.0.0
-azure-mgmt-web==0.47.0
-azure-mgmt-compute==5.0.0
-azure-mgmt-authorization==0.60.0
+#azure-mgmt-storage==7.1.0
+#azure-mgmt-monitor==0.5.2
+#azure-mgmt-sql==0.11.0
+#azure-mgmt-security==0.4.1
+#azure-mgmt-keyvault==1.1.0
+#azure-mgmt-network==2.5.1
+#azure-mgmt-redis==6.0.0
+#azure-mgmt-web==0.47.0
+#azure-mgmt-compute==5.0.0
+#azure-mgmt-authorization==0.60.0
 
 # Aliyun / Alibaba Cloud Provider
-aliyun-python-sdk-core>=2.13.4
-aliyun-python-sdk-ram>=3.0.1
-aliyun-python-sdk-ocs>=0.0.4
-aliyun-python-sdk-sts>=3.0.1
-aliyun-python-sdk-actiontrail>=2.0.0
-aliyun-python-sdk-vpc>=3.0.5
-aliyun-python-sdk-ecs>=4.16.10
-aliyun-python-sdk-rds>=2.3.9
-aliyun-python-sdk-kms>=2.6.0
-oss2>=2.8.0
+#aliyun-python-sdk-core>=2.13.4
+#aliyun-python-sdk-ram>=3.0.1
+#aliyun-python-sdk-ocs>=0.0.4
+#aliyun-python-sdk-sts>=3.0.1
+#aliyun-python-sdk-actiontrail>=2.0.0
+#aliyun-python-sdk-vpc>=3.0.5
+#aliyun-python-sdk-ecs>=4.16.10
+#aliyun-python-sdk-rds>=2.3.9
+#aliyun-python-sdk-kms>=2.6.0
+#oss2>=2.8.0
 
 # Oracle Cloud Infrastructure Provider
-oci>=2.2.4
+#oci>=2.2.4


### PR DESCRIPTION
# Description
Commenting out those requirements saves 300MB of image size. Testing locally I have not had any issues using the image in `task docker:run-local`.

Fixes # (issue)
SECURE-3185

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
